### PR TITLE
Allowed const volatile register spaces to omit initialization

### DIFF
--- a/lib/Dialect/CoreDSL/CoreDSLOps.cpp
+++ b/lib/Dialect/CoreDSL/CoreDSLOps.cpp
@@ -453,7 +453,10 @@ LogicalResult RegisterOp::verify() {
     if (init.getElementType() != getRegType())
       return emitError("initial value type must match the register type");
   } else {
-    if (getIsConst())
+    // Do not error for const volatile register spaces, as in this case the
+    // value may be changed arbitrarily by an external entity. Thus, the
+    // assigned value may well never be read at all
+    if (getIsConst() && !getIsVolatile())
       return emitError("Const registers must be initialized");
   }
 

--- a/lib/Dialect/CoreDSL/CoreDSLOps.cpp
+++ b/lib/Dialect/CoreDSL/CoreDSLOps.cpp
@@ -454,8 +454,8 @@ LogicalResult RegisterOp::verify() {
       return emitError("initial value type must match the register type");
   } else {
     // Do not error for const volatile register spaces, as in this case the
-    // value may be changed arbitrarily by an external entity. Thus, the
-    // assigned value may well never be read at all
+    // value may be changed arbitrarily by an external entity. Because of this,
+    // it is possible for the initially assigned value to never be read at all
     if (getIsConst() && !getIsVolatile())
       return emitError("Const registers must be initialized");
   }


### PR DESCRIPTION
Fix https://github.com/esa-tu-darmstadt/Shortnail/issues/2. Shortnail will now not error when a const volatile address space remains uninitialized.