### PR TITLE
Allow negative range indices

### DIFF
--- a/docs/CoreDSLDialect.md
+++ b/docs/CoreDSLDialect.md
@@ -276,8 +276,8 @@ Effects: `MemoryEffects::Effect{}`
 
 <table>
 <tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
-<tr><td><code>from</code></td><td>::mlir::IntegerAttr</td><td>index attribute whose value is non-negative</td></tr>
-<tr><td><code>to</code></td><td>::mlir::IntegerAttr</td><td>index attribute whose value is non-negative</td></tr>
+<tr><td><code>from</code></td><td>::mlir::IntegerAttr</td><td>index attribute</td></tr>
+<tr><td><code>to</code></td><td>::mlir::IntegerAttr</td><td>index attribute</td></tr>
 </table>
 
 #### Operands:
@@ -329,8 +329,8 @@ Effects: `MemoryEffects::Effect{}`
 
 <table>
 <tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
-<tr><td><code>from</code></td><td>::mlir::IntegerAttr</td><td>index attribute whose value is non-negative</td></tr>
-<tr><td><code>to</code></td><td>::mlir::IntegerAttr</td><td>index attribute whose value is non-negative</td></tr>
+<tr><td><code>from</code></td><td>::mlir::IntegerAttr</td><td>index attribute</td></tr>
+<tr><td><code>to</code></td><td>::mlir::IntegerAttr</td><td>index attribute</td></tr>
 </table>
 
 #### Operands:
@@ -476,8 +476,8 @@ Examples:
 
 <table>
 <tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
-<tr><td><code>from</code></td><td>::mlir::IntegerAttr</td><td>index attribute whose value is non-negative</td></tr>
-<tr><td><code>to</code></td><td>::mlir::IntegerAttr</td><td>index attribute whose value is non-negative</td></tr>
+<tr><td><code>from</code></td><td>::mlir::IntegerAttr</td><td>index attribute</td></tr>
+<tr><td><code>to</code></td><td>::mlir::IntegerAttr</td><td>index attribute</td></tr>
 <tr><td><code>sym</code></td><td>::mlir::FlatSymbolRefAttr</td><td>flat symbol reference attribute</td></tr>
 </table>
 
@@ -718,8 +718,8 @@ coredsl.set @MEM[%addr : ui32, 0:3] = %3 : ui32 // big-endian
 
 <table>
 <tr><th>Attribute</th><th>MLIR Type</th><th>Description</th></tr>
-<tr><td><code>from</code></td><td>::mlir::IntegerAttr</td><td>index attribute whose value is non-negative</td></tr>
-<tr><td><code>to</code></td><td>::mlir::IntegerAttr</td><td>index attribute whose value is non-negative</td></tr>
+<tr><td><code>from</code></td><td>::mlir::IntegerAttr</td><td>index attribute</td></tr>
+<tr><td><code>to</code></td><td>::mlir::IntegerAttr</td><td>index attribute</td></tr>
 <tr><td><code>sym</code></td><td>::mlir::FlatSymbolRefAttr</td><td>flat symbol reference attribute</td></tr>
 </table>
 

--- a/include/shortnail/Dialect/CoreDSL/CoreDSLOps.td
+++ b/include/shortnail/Dialect/CoreDSL/CoreDSLOps.td
@@ -274,8 +274,8 @@ class CoreDSL_AccessOp<string mnemonic, string lhsAssemblyFormat, string rhsAsse
     : CoreDSL_Op<mnemonic, traits> {
 
   let arguments = !con((ins Optional<AllOfType<[HWArithIntegerType, AnyUnsignedInteger]>>:$base, 
-                        OptionalAttr<ConfinedAttr<IndexAttr, [IntNonNegative]>>:$from,
-                        OptionalAttr<ConfinedAttr<IndexAttr, [IntNonNegative]>>:$to), additionalArgs);
+                        OptionalAttr<IndexAttr>:$from,
+                        OptionalAttr<IndexAttr>:$to), additionalArgs);
   let results = res;
 
   let assemblyFormat = lhsAssemblyFormat # "`` custom<RangedAccess>(\"" # isRangeAccessOptional # "\", $base, type($base), $from, $to) " # rhsAssemblyFormat;
@@ -291,24 +291,24 @@ class CoreDSL_AccessOp<string mnemonic, string lhsAssemblyFormat, string rhsAsse
       if (hasSingleIdxAccess()) {
         return 1;
       }
-      int64_t width = static_cast<int64_t>(getFrom()->getZExtValue()) -
-                      static_cast<int64_t>(getTo()->getZExtValue());
+      int64_t width = static_cast<int64_t>(getFrom()->getSExtValue()) -
+                      static_cast<int64_t>(getTo()->getSExtValue());
       return std::abs(width) + 1;
     }
 
     bool $cppClass::hasSingleIdxAccess() {
-      return !getTo() || !getFrom() || getFrom()->getZExtValue() == getTo()->getZExtValue();
+      return !getTo() || !getFrom() || getFrom()->getSExtValue() == getTo()->getSExtValue();
     }
 
     bool $cppClass::reversedAccessOrder() {
-      return getTo() && getFrom() && getFrom()->getZExtValue() < getTo()->getZExtValue();
+      return getTo() && getFrom() && getFrom()->getSExtValue() < getTo()->getSExtValue();
     }
 
     }] # folderPrototype # [{ {
       if (hasSingleIdxAccess() && getFrom()) {
         bool changed = false;
         // canonicalize single bit accesses such as val[%base, 0:0] to val[%base]
-        if (getBase() && getFrom()->getZExtValue() == 0) {
+        if (getBase() && getFrom()->getSExtValue() == 0) {
           removeFromAttr();
           changed = true;
         }

--- a/lib/Dialect/CoreDSL/CoreDSLOps.cpp
+++ b/lib/Dialect/CoreDSL/CoreDSLOps.cpp
@@ -833,13 +833,13 @@ LogicalResult GetOp::canonicalize(GetOp op, PatternRewriter &rewriter) {
   if (!resolvedSym)
     return failure();
 
-  // Non const target -> exit!
+  // Non const target or volatile target -> exit!
   assert(isa<GetSetOpInterface>(resolvedSym));
   assert(isa<RegisterOp>(resolvedSym));
-  if (!cast<RegisterOp>(resolvedSym).getIsConst())
+  auto regOp = cast<RegisterOp>(resolvedSym);
+  if (!regOp.getIsConst() || regOp.getIsVolatile())
     return failure();
 
-  auto regOp = cast<RegisterOp>(resolvedSym);
   auto initOpt = regOp.getInitializer();
   assert(initOpt.has_value());
   assert(isa<DenseIntElementsAttr>(initOpt.value()));

--- a/lib/Dialect/CoreDSL/CoreDSLOps.cpp
+++ b/lib/Dialect/CoreDSL/CoreDSLOps.cpp
@@ -589,16 +589,20 @@ static LogicalResult checkBitAccessOperation(BitOpTy op) {
   }
 
   if (auto from = op.getFrom()) {
-    if (from->isNegative()) {
-      return op->emitError("bit index 'from' must not be negative");
+    if (!op.getBase() && from->isNegative()) {
+      return op.emitError(
+          "Negative indices in an access range are only allowed when using a "
+          "base index, as they will always be out of range without one");
     }
     if (from->getZExtValue() >= valueWidth) {
       return op->emitError("bit index 'from' exceeds input value width");
     }
 
     if (auto to = op.getTo()) {
-      if (to->isNegative()) {
-        return op->emitError("bit index 'to' must not be negative");
+      if (!op.getBase() && to->isNegative()) {
+        return op.emitError(
+            "Negative indices in an access range are only allowed when using a "
+            "base index, as they will always be out of range without one");
       }
       if (to->getZExtValue() >= valueWidth) {
         return op->emitError("bit index 'to' exceeds input value width");

--- a/lib/Dialect/CoreDSL/CoreDSLOps.cpp
+++ b/lib/Dialect/CoreDSL/CoreDSLOps.cpp
@@ -589,11 +589,17 @@ static LogicalResult checkBitAccessOperation(BitOpTy op) {
   }
 
   if (auto from = op.getFrom()) {
+    if (from->isNegative()) {
+      return op->emitError("bit index 'from' must not be negative");
+    }
     if (from->getZExtValue() >= valueWidth) {
       return op->emitError("bit index 'from' exceeds input value width");
     }
 
     if (auto to = op.getTo()) {
+      if (to->isNegative()) {
+        return op->emitError("bit index 'to' must not be negative");
+      }
       if (to->getZExtValue() >= valueWidth) {
         return op->emitError("bit index 'to' exceeds input value width");
       }
@@ -718,16 +724,18 @@ static LogicalResult checkAccess(AccessOpTy op, Type requiredType) {
     // check that neither the offsets nor the access width violate the max index
     // width!
     if (auto from = op.getFrom()) {
-      auto reqBitWidth = getAPIntBitWidth(from.value(), false);
+      auto reqBitWidth = getAPIntBitWidth(from.value(), from->isNegative());
       if (reqBitWidth > info->maxIdxWidth)
         return op.emitError("`from` offset exceeds the register/address "
                             "space's address width of ")
                << info->maxIdxWidth << " with a required offset bit width of "
                << reqBitWidth;
 
-      uint64_t startOffset = from.value().getZExtValue();
+      // Using sign extension is safe here, as the MSB will only be set as a
+      // sign bit by MLIR
+      int64_t startOffset = from->getSExtValue();
       if (auto to = op.getTo()) {
-        auto reqBitWidth = getAPIntBitWidth(to.value(), false);
+        auto reqBitWidth = getAPIntBitWidth(to.value(), to->isNegative());
         if (reqBitWidth > info->maxIdxWidth)
           return op.emitError("`to` offset exceeds the register/address "
                               "space's address width of ")
@@ -738,12 +746,24 @@ static LogicalResult checkAccess(AccessOpTy op, Type requiredType) {
           return op.emitError("the access width exceeds the address width of "
                               "register/address space");
 
-        startOffset = std::min(to.value().getZExtValue(), startOffset);
+        startOffset = std::min(to->getSExtValue(), startOffset);
       }
-
-      if (info->size != 0 && startOffset + op.getAccessWidth() > info->size) {
-        return op.emitError("the access range exceeds the bounds of the "
-                            "register/address space");
+      // If there is a base offset, we cannot determine whether accesses are
+      // out of bounds without knowing the access value
+      if (!op.getBase()) {
+        // if there is only a range given, not a base index, negative values
+        // will always be out of bounds
+        if (startOffset < 0) {
+          return op.emitError(
+              "Negative indices in an access range are only allowed when using "
+              "a base index, as they will always be out of bounds without one");
+        }
+        const uint64_t startOffsetUnsigned = static_cast<uint64_t>(startOffset);
+        if (info->size != 0 &&
+            startOffsetUnsigned + op.getAccessWidth() > info->size) {
+          return op.emitError("the access range exceeds the bounds of the "
+                              "register/address space");
+        }
       }
     }
 
@@ -773,7 +793,7 @@ static Operation *genericResolveSymbol(Operation *op, StringRef sym) {
   return lookupSymbolInModule<GetSetOpInterface>(op, sym);
 }
 
-static RegisterOp fullyResolveReference(Operation *op, unsigned &startOffset) {
+static RegisterOp fullyResolveReference(Operation *op, int64_t &startOffset) {
   if (auto regOp = dyn_cast<RegisterOp>(op))
     return regOp;
   if (isa<AliasOp>(op)) {
@@ -787,7 +807,7 @@ static RegisterOp fullyResolveReference(Operation *op, unsigned &startOffset) {
 
 LogicalResult GetOp::canonicalize(GetOp op, PatternRewriter &rewriter) {
   // Perform constant propagation, replace by a constant if feasible!
-  unsigned initIdx = 0;
+  int64_t initIdx = 0;
   if (auto accessIdx = op.getBase()) {
     auto *defOp = accessIdx.getDefiningOp();
     if (!defOp || !defOp->hasTrait<OpTrait::ConstantLike>())
@@ -802,7 +822,7 @@ LogicalResult GetOp::canonicalize(GetOp op, PatternRewriter &rewriter) {
     return failure();
 
   if (auto from = op.getFrom())
-    initIdx += from->getZExtValue();
+    initIdx += from->getSExtValue();
 
   auto resolvedSym = op.resolveSymbol();
   resolvedSym = fullyResolveReference(resolvedSym, initIdx);

--- a/test/CoreDSL/illegal_mem_expr.mlir
+++ b/test/CoreDSL/illegal_mem_expr.mlir
@@ -197,8 +197,8 @@ coredsl.isax "" {
 
 coredsl.isax "" {
     coredsl.addrspace core_mem @MEM : (ui32) -> ui8
-    // expected-error @+1 {{'coredsl.get' op attribute 'from' failed to satisfy constraint: index attribute whose value is non-negative}}
-    %1 = coredsl.get @MEM[-1:0] : ui8
+    // expected-error @+1 {{Negative indices in an access range are only allowed when using a base index, as they will always be out of bounds without one}}
+    %1 = coredsl.get @MEM[-1:0] : ui16
 }
 
 // -----


### PR DESCRIPTION
Fix https://github.com/esa-tu-darmstadt/Shortnail/issues/1. Removes the IntNonNegative limit on CoreDSL_AccessOp. Most of the changes are changing getZExtValue() to getSExtValue(). The others are changes to the out of bounds checks to respect signedness.