### PR TITLE
Added back comb dialect, because it is emitted by treenail

### DIFF
--- a/include/shortnail/Dialect/CoreDSL/CoreDSL.td
+++ b/include/shortnail/Dialect/CoreDSL/CoreDSL.td
@@ -93,6 +93,9 @@ def CoreDSL_Dialect : Dialect {
       "arith::ArithDialect",
       "hwarith::HWArithDialect",
       "func::FuncDialect",
+      // Needed because treenail emits comb.sub and comb.add for operations on
+      // signless integers, such as in the scf.for codegen
+      "comb::CombDialect",
     ];
     let cppNamespace = "::mlir::coredsl";
 }

--- a/lib/Dialect/CoreDSL/CoreDSLDialect.cpp
+++ b/lib/Dialect/CoreDSL/CoreDSLDialect.cpp
@@ -9,6 +9,7 @@
 #include "shortnail/Dialect/CoreDSL/CoreDSLDialect.h"
 #include "shortnail/Dialect/CoreDSL/CoreDSLOps.h"
 
+#include "circt/Dialect/Comb/CombDialect.h"
 #include "circt/Dialect/HW/HWDialect.h"
 #include "circt/Dialect/HWArith/HWArithDialect.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlow.h"


### PR DESCRIPTION
I removed this by mistake, as it was never used anywhere in shortnail, but it is needed, as treenail sometimes generates it, as in the scf.for codegen. Otherwise we get errors, because an unknown dialect is used